### PR TITLE
Fix: update macOS and iOS deployment target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,7 +218,7 @@ _pkginfo.txt
 ClientBin/
 Bin~/
 upm-ci~/
-Plugin~/webrtc/*
+Plugin~/webrtc*/*
 WebRTC~/CodeCoverage
 WebRTC~/TestResults-*
 *.dbmdl

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.22)
+include(CMakePrintHelpers)
 
 set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET
-    "10.0"
+    "15.0"
     CACHE STRING "Minimum iOS deployment version")
 set(CMAKE_OSX_DEPLOYMENT_TARGET
-    "10.12"
+    "10.13"
     CACHE STRING "Minimum OS X deployment version")
 
 project(
@@ -42,6 +43,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(XCODE)
+  cmake_print_variables(XCODE_VERSION)
   if(${XCODE_VERSION} VERSION_GREATER_EQUAL 12.0.0 AND ${XCODE_VERSION}
                                                        VERSION_LESS 11.0.0)
     message(

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -92,7 +92,7 @@ set_target_properties(WebRTCLib PROPERTIES CXX_VISIBILITY_PRESET hidden
                                            VISIBILITY_INLINES_HIDDEN ON)
 
 if(iOS OR macOS)
-  target_sources(WebRTCLib PRIVATE ../libcxx/debug.cpp)
+#  target_sources(WebRTCLib PRIVATE ../libcxx/debug.cpp)
 else()
   target_sources(WebRTCLib PRIVATE UnityVulkanInterfaceFunctions.cpp
                                    UnityVulkanInterfaceFunctions.h)


### PR DESCRIPTION
Compile error occurred when build build_plugin_macos and iOS on Xcode 15.4.
So I remove debug script for avoid compile error.

I think that is only use for debug. so, no worry for release build.